### PR TITLE
파라미터 소수점 두자리까지 출력

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -73,7 +73,7 @@ function showCurrentParam(radius, degreeStep, radiusStep, colorStep) {
 
   param.style.textAlign = "center";
   param.className = 'currentParam'
-  param.textContent = `radius: ${radius}  degreeStep: ${degreeStep}  radiusStep: ${radiusStep}  colorStep: ${colorStep}`
+  param.textContent = `radius: ${radius.toFixed(2)}  degreeStep: ${degreeStep.toFixed(2)}  radiusStep: ${radiusStep.toFixed(2)}  colorStep: ${colorStep}`
   document.getElementsByTagName('body')[0].insertAdjacentElement('afterbegin', param)
 }
 


### PR DESCRIPTION
## Related Issue
Fixes #4 
실수형 파라미터를 소수점 두자리까지 출력되도록 수정했습니다.

## 실행화면
https://juyeong0413.github.io/phg98p5sample/